### PR TITLE
Update docs considering changes on Rocky 24R2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing
 
-For contributing to this project, please refer to the [PyAnsys Developer's Guide].
+For contributing to this project, please refer to the [PyRocky Developer's Guide].
 
-[PyAnsys Developer's Guide]: https://dev.docs.pyansys.com/how-to/contributing.html
+[PyRocky Developer's Guide]: https://rocky.docs.pyansys.com/version/dev/contributing.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
-# Contributing
+# Contribute
 
-For contributing to this project, please refer to the [PyRocky Developer's Guide].
+For contributing to this project, see the [PyRocky Developer's Guide].
 
 [PyRocky Developer's Guide]: https://rocky.docs.pyansys.com/version/dev/contributing.html

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ PyRocky
 
 |pyansys| |MIT| |python| |pypi| |codecov| |MIT| |black| |pre-commit|
 
-PyRocky is a Python client library to create, run and post-processing
+PyRocky is a Python client library to create, run, and postprocess
 particle dynamics simulations using `Ansys Rocky <https://www.ansys.com/products/fluids/ansys-rocky>`_,
 the most powerful DEM (discrete element method) software in the market.
 
@@ -18,13 +18,13 @@ The documentation has five sections:
 - `Getting started <https://rocky.docs.pyansys.com/version/stable/getting_started/index.html>`_: Learn
   how to install PyRocky in user mode and then launch it.
 - `User guide <https://rocky.docs.pyansys.com/version/stable/user_guide/index.html>`_: Understand how to
-  use the Rocky PrePost Scripting with PyRocky.
-- `API reference <https://rocky.docs.pyansys.com/version/stable/api/index.html>`_: Understand PyRocky API
-  endpoints, their capabilities, and how to interact with them programmatically.
+  use Rocky PrePost Scripting with PyRocky.
+- `API reference <https://rocky.docs.pyansys.com/version/stable/api/index.html>`_: Explore PyRocky
+  available methods and classes.
 - `Examples <https://rocky.docs.pyansys.com/version/stable/examples/index.html>`_: Explore end-to-end
   examples that show how to use PyRocky.
-- `Contribute <https://rocky.docs.pyansys.com/version/stable/contributing.html>`_: Learn how to contribute
-  to the PyRocky codebase or documentation.
+- `Contribute <https://rocky.docs.pyansys.com/version/stable/contributing.html>`_: Learn how to
+  contribute to the PyRocky codebase or documentation.
 
 In the upper right corner of the documentation's title bar, there is an option
 for switching from viewing the documentation for the latest stable release

--- a/README.rst
+++ b/README.rst
@@ -3,10 +3,9 @@ PyRocky
 
 |pyansys| |MIT| |python| |pypi| |codecov| |MIT| |black| |pre-commit|
 
-PyRocky is a Python client library for remotely controlling
-`Ansys Rocky <https://www.ansys.com/products/fluids/ansys-rocky>`_,
-which is the most powerful software in the market for performing
-DEM (discrete element method) simulations.
+PyRocky is a Python client library to create, run and post-processing
+particle dynamics simulations using `Ansys Rocky <https://www.ansys.com/products/fluids/ansys-rocky>`_,
+the most powerful DEM (discrete element method) software in the market.
 
 Documentation and issues
 ------------------------
@@ -19,7 +18,7 @@ The documentation has five sections:
 - `Getting started <https://rocky.docs.pyansys.com/version/stable/getting_started/index.html>`_: Learn
   how to install PyRocky in user mode and then launch it.
 - `User guide <https://rocky.docs.pyansys.com/version/stable/user_guide/index.html>`_: Understand how to
-  use the Rocky PrePost API with PyRocky.
+  use the Rocky PrePost Scripting with PyRocky.
 - `API reference <https://rocky.docs.pyansys.com/version/stable/api/index.html>`_: Understand PyRocky API
   endpoints, their capabilities, and how to interact with them programmatically.
 - `Examples <https://rocky.docs.pyansys.com/version/stable/examples/index.html>`_: Explore end-to-end

--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -23,6 +23,6 @@ Packages = Google
 Vocab = ANSYS
 
 [*.{md,rst}]
-
-# Apply the following styles
 BasedOnStyles = Vale, Google
+Google.Colons = NO
+Google.Heading = NO

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -4,11 +4,6 @@
 Getting started
 ===============
 
-PyRocky is a Python client library for remotely controlling
-`Ansys Rocky <https://www.ansys.com/products/fluids/ansys-rocky>`_,
-which is the most powerful software in the market for performing
-DEM (discrete element method) simulations.
-
 Install PyRocky
 ---------------
 
@@ -51,9 +46,9 @@ Connect to an existing session
 
 Assume that a Rocky session is started with the ``--pyrocky`` option:
 
-.. code:: bat
+.. code::
 
-   C:\Program Files\Ansys Inc\v241\Rocky> bin\Rocky.exe --pyrocky
+   C:\Program Files\Ansys Inc\v242\Rocky\bin\Rocky.exe --pyrocky
 
 When the Rocky session is started in this way, you can connect to it with PyRocky:
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,7 +1,7 @@
 PyRocky
 #######
 
-PyRocky is a Python client library to create, run and post-processing
+PyRocky is a Python client library to create, run, and postprocess
 particle dynamics simulations using `Ansys Rocky <https://www.ansys.com/products/fluids/ansys-rocky>`_,
 the most powerful DEM (discrete element method) software in the market.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,5 +1,11 @@
 PyRocky
 #######
+
+PyRocky is a Python client library to create, run and post-processing
+particle dynamics simulations using `Ansys Rocky <https://www.ansys.com/products/fluids/ansys-rocky>`_,
+the most powerful DEM (discrete element method) software in the market.
+
+
 .. grid:: 2
    :gutter: 2 3 3 4
 
@@ -9,7 +15,6 @@ PyRocky
       :link-type: doc
 
       Learn how to install PyRocky in user mode and then launch it.
-
 
    .. grid-item-card:: User guide :material-regular:`book`
       :padding: 2 2 2 2
@@ -35,13 +40,6 @@ PyRocky
       :link-type: doc
 
       Explore end-to-end examples that show how to use PyRocky.
-
-   .. grid-item-card:: Contribute :fa:`people-group`
-      :padding: 2 2 2 2
-      :link: contributing
-      :link-type: doc
-
-      Learn how to contribute to the PyRocky codebase or documentation.
 
 .. toctree::
    :hidden:

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -4,10 +4,10 @@
 User guide
 ==========
 
-Use the Rocky PrePost Scripting
--------------------------------
+Use Rocky PrePost Scripting
+---------------------------
 
-In its current shape, PyRocky is a thin layer that enables remote calls to Rocky using the
+In its current form, PyRocky is a thin layer that enables remote calls to Rocky using the
 PrePost Scripting API. This API is available through the ``RockyClient.api`` object. For
 example, the following code creates a project and saves it to disk:
 
@@ -26,13 +26,13 @@ example, the following code creates a project and saves it to disk:
 To view comprehensive PrePost Scripting documentation, in the Rocky app, select
 **Help > Manuals > PrePost Scripting**.
 
-Most methods of the PrePost Scripting, when called through PyRocky, works in the exact same way
-they work in the Rocky built-in Python Shell. However, there are differences worth noting:
+Most methods of PrePost Scripting, when called through PyRocky, work in exactly the same way
+as in the Rocky built-in Python shell. However, there are differences worth noting:
 
-- ``KAStudy.GetTimeSet``: on PyRocky this method returns a ``numpy.array`` of simulation time
+- ``RAStudy.GetTimeSet``: In PyRocky, this method returns a ``numpy.array`` of simulation time
   steps in seconds (instead of a ``TimeSet`` object).
-- ``KAElementItem.GetCurve``: this method is not supported by PyRocky. Use ``GetNumpyCurve`` to
-  get resulting curves from study entities.
+- ``KAElementItem.GetCurve``: This method is not supported by PyRocky. Use the ``GetNumpyCurve``
+  method to get resulting curves from study entities.
 
 
 Known issues

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -4,24 +4,35 @@
 User guide
 ==========
 
+Use the Rocky PrePost Scripting
+-------------------------------
 
-Use the Rocky PrePost API
--------------------------
+In its current shape, PyRocky is a thin layer that enables remote calls to Rocky using the
+PrePost Scripting API. This API is available through the ``RockyClient.api`` object. For
+example, the following code creates a project and saves it to disk:
 
-Most of the Rocky PrePost API is available through the ``api`` object. For example,
-the following code creates a project and saves it to disk:
-
+.. vale off
 ..  code:: python
-
+    rocky = pyrocky.launch_rocky()
     api = rocky.api
+
     project = api.CreateProject()
     study = project.GetStudy()
     study.SetName("My Study")
 
     api.SaveProject("my-project.rocky"))
+.. vale on
 
-To view comprehensive PrePost API documentation, in the Rocky app, select
-**Help > Manuals > API PrePost**.
+To view comprehensive PrePost Scripting documentation, in the Rocky app, select
+**Help > Manuals > PrePost Scripting**.
+
+Most methods of the PrePost Scripting, when called through PyRocky, works in the exact same way
+they work in the Rocky built-in Python Shell. However, there are differences worth noting:
+
+- ``KAStudy.GetTimeSet``: on PyRocky this method returns a ``numpy.array`` of simulation time
+  steps in seconds (instead of a ``TimeSet`` object).
+- ``KAElementItem.GetCurve``: this method is not supported by PyRocky. Use ``GetNumpyCurve`` to
+  get resulting curves from study entities.
 
 
 Known issues
@@ -29,4 +40,3 @@ Known issues
 - When opened with the Rocky UI visible (non-headless mode), PyRocky cannot deal with confirmation
   or error dialogs. For example, a call to the ``CloseProject()`` method asks for confirmation,
   causing PyRocky to freeze until **OK** or **Cancel** is clicked in the Rocky UI.
-- Some API methods may not work.

--- a/doc/styles/Vocab/ANSYS/accept.txt
+++ b/doc/styles/Vocab/ANSYS/accept.txt
@@ -5,3 +5,4 @@ dialogs
 (?i)PrePost
 (?i)API
 (?i)pyrocky
+[Pp]ostprocess

--- a/src/ansys/rocky/core/client.py
+++ b/src/ansys/rocky/core/client.py
@@ -19,7 +19,10 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""Module with the client operations of Rocky."""
+"""
+Module that defines the RockyClient class, which act as a proxy for a Rocky application
+session.
+"""
 from collections.abc import Callable, Generator
 import pickle
 from typing import Any, Final

--- a/src/ansys/rocky/core/client.py
+++ b/src/ansys/rocky/core/client.py
@@ -20,8 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 """
-Module that defines the RockyClient class, which act as a proxy for a Rocky application
-session.
+Module that defines the ``RockyClient`` class, which acts as a proxy for a Rocky
+application session.
 """
 from collections.abc import Callable, Generator
 import pickle

--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -19,7 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""Module for launching operations of the Rocky backend."""
+"""Module that exposes functions to launch Rocky application."""
 import contextlib
 import os
 from pathlib import Path

--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -19,7 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""Module that exposes functions to launch Rocky application."""
+"""Module that exposes functions to launch a Rocky application session."""
 import contextlib
 import os
 from pathlib import Path


### PR DESCRIPTION
- Explicit list PyRocky differences on GetTimeSet and GetCurves methods
- Use "PrePost Scripting" instead of "PrePost API" to refers to the Rocky scripting feature (changed on 24R2)
- Fix the docstring content of launcher.py
- CONTRIBUTING.md now points to the PyRock Contributing section of PyRocky Developer's Guide
- Adds a small intro to the Developer's guide index page and remove the "How to Contribute" card (not something we want to highlight for the casual user)