### PR TITLE
Fix import typo on Getting Started Instruction

### DIFF
--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -25,7 +25,7 @@ interact with the software:
 
 ..  code:: python
 
-    import ansys.rocky.rocky as pyrocky
+    import ansys.rocky.core as pyrocky
 
     rocky = pyrocky.launch_rocky()
 
@@ -54,6 +54,6 @@ When the Rocky session is started in this way, you can connect to it with PyRock
 
 .. code:: python
 
-    import ansys.rocky.rocky as pyrocky
+    import ansys.rocky.core as pyrocky
 
     rocky = pyrocky.connect_to_rocky()


### PR DESCRIPTION
Fix Getting Started Documentation imports of pyrocky. #44 