### PR TITLE
Terminate existing session when attempting to launch Rocky

### DIFF
--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -40,7 +40,7 @@ def launch_rocky(
     *,
     headless: bool = True,
     server_port: int = DEFAULT_SERVER_PORT,
-    terminate_existing_session: bool = False,
+    close_existing: bool = False,
 ) -> RockyClient:
     """
     Launch the Rocky executable with the PyRocky server enabled.
@@ -57,7 +57,7 @@ def launch_rocky(
         Whether to launch Rocky in headless mode. The default is ``True``.
     server_port: int, optional
         Set the port for Rocky RPC server.
-    terminate_existing_session: bool, optional
+    close_existing: bool, optional
         Checks if a session exists under the given server_port and closes it
         before attempting to launch a new session.
 
@@ -70,7 +70,7 @@ def launch_rocky(
         rocky_exe = Path(rocky_exe)
 
     if _is_port_busy(server_port):
-        if terminate_existing_session:
+        if close_existing:
             # Will try to connect to an existing session using the
             # given server port and attempt to close it.
             client = connect_to_rocky(port=server_port)

--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -40,6 +40,7 @@ def launch_rocky(
     *,
     headless: bool = True,
     server_port: int = DEFAULT_SERVER_PORT,
+    terminate_existing_session: bool = False
 ) -> RockyClient:
     """
     Launch the Rocky executable with the PyRocky server enabled.
@@ -56,6 +57,9 @@ def launch_rocky(
         Whether to launch Rocky in headless mode. The default is ``True``.
     server_port: int, optional
         Set the port for Rocky RPC server.
+    terminate_existing_session: bool, optional
+        Checks if a session exists under the given server_port and closes it 
+        before attempting to launch a new session.
 
     Returns
     -------
@@ -66,7 +70,17 @@ def launch_rocky(
         rocky_exe = Path(rocky_exe)
 
     if _is_port_busy(server_port):
-        raise RockyLaunchError(f"Port {server_port} is already in use.")
+        if terminate_existing_session:
+            # Will try to connect to an existing session using the 
+            # given server port and attempt to close it.
+            client = connect_to_rocky(port=server_port)
+            try:    
+                client.close()
+            except CommunicationError:
+                # Maybe the session closed in the meantime so we just pass
+                pass
+        else:
+            raise RockyLaunchError(f"Port {server_port} is already in use.")
 
     if rocky_exe is None:
         awp_roots = [k for k in os.environ.keys() if k.startswith("AWP_ROOT")]

--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -40,7 +40,7 @@ def launch_rocky(
     *,
     headless: bool = True,
     server_port: int = DEFAULT_SERVER_PORT,
-    terminate_existing_session: bool = False
+    terminate_existing_session: bool = False,
 ) -> RockyClient:
     """
     Launch the Rocky executable with the PyRocky server enabled.
@@ -58,7 +58,7 @@ def launch_rocky(
     server_port: int, optional
         Set the port for Rocky RPC server.
     terminate_existing_session: bool, optional
-        Checks if a session exists under the given server_port and closes it 
+        Checks if a session exists under the given server_port and closes it
         before attempting to launch a new session.
 
     Returns
@@ -71,10 +71,10 @@ def launch_rocky(
 
     if _is_port_busy(server_port):
         if terminate_existing_session:
-            # Will try to connect to an existing session using the 
+            # Will try to connect to an existing session using the
             # given server port and attempt to close it.
             client = connect_to_rocky(port=server_port)
-            try:    
+            try:
                 client.close()
             except CommunicationError:
                 # Maybe the session closed in the meantime so we just pass

--- a/tests/test_pyrocky.py
+++ b/tests/test_pyrocky.py
@@ -157,14 +157,15 @@ def test_pyrocky_launch_multiple_servers():
         with pytest.raises(RockyLaunchError, match=r"Port \d+ is already in use"):
             pyrocky.launch_rocky()
 
+
 def test_close_existing_session():
     """
-    Launches a pyrocky session on top another one using the 
-    same server port. PyRocky should attempt closing the 
+    Launches a pyrocky session on top another one using the
+    same server port. PyRocky should attempt closing the
     existing session before launching the second one.
     """
     from ansys.rocky.core.client import _get_numerical_version
-    
+
     rocky_one = pyrocky.launch_rocky()
     rocky_two = pyrocky.launch_rocky(close_existing=True)
 

--- a/tests/test_pyrocky.py
+++ b/tests/test_pyrocky.py
@@ -156,3 +156,18 @@ def test_pyrocky_launch_multiple_servers():
 
         with pytest.raises(RockyLaunchError, match=r"Port \d+ is already in use"):
             pyrocky.launch_rocky()
+
+def test_close_existing_session():
+    """
+    Launches a pyrocky session on top another one using the 
+    same server port. PyRocky should attempt closing the 
+    existing session before launching the second one.
+    """
+    from ansys.rocky.core.client import _get_numerical_version
+    
+    rocky_one = pyrocky.launch_rocky()
+    rocky_two = pyrocky.launch_rocky(close_existing=True)
+
+    assert _get_numerical_version(rocky_two.api) is not None
+
+    rocky_two.close()


### PR DESCRIPTION
When a Rocky session hangs, which can happen due to multiple reasons, pyRocky can raise an error because the server_port is already in use. An additional argument called terminate_existing_session was included under Rocky's launcher to force the existing session to close before launching a new one using the same server_port. This gives the user the flexibility to avoid killing the Rocky process or manually connecting to the existing session to close it.

#103 