### PR TITLE
Return rocky version through a function

### DIFF
--- a/src/ansys/rocky/core/client.py
+++ b/src/ansys/rocky/core/client.py
@@ -36,9 +36,6 @@ if TYPE_CHECKING:
 
 DEFAULT_SERVER_PORT: Final[int] = 50615
 _ROCKY_API: Pyro5.api.Proxy | None = None
-_ROCKY_VERSION: int | None = (
-    None  # Rocky version as integer (24R2 becomes 242, 25R1 becomes 251, ...)
-)
 
 
 def connect_to_rocky(
@@ -60,13 +57,12 @@ def connect_to_rocky(
         Client object for interacting with the Rocky app.
     """
     uri = f"PYRO:rocky.api@{host}:{port}"
-    global _ROCKY_API, _ROCKY_VERSION
+    global _ROCKY_API
 
     if _ROCKY_API is None:
         register_proxies()
 
     _ROCKY_API = Pyro5.api.Proxy(uri)
-    _ROCKY_VERSION = _get_numerical_version(_ROCKY_API)
 
     rocky_client = RockyClient(_ROCKY_API)
     return rocky_client

--- a/src/ansys/rocky/core/serializers.py
+++ b/src/ansys/rocky/core/serializers.py
@@ -57,11 +57,12 @@ def _ApiElementProxySerializer(obj: ApiElementProxy) -> dict:
     Serialize an `ApiElementProxy` ensuring backward compatibility with
     ROCKY 24.2 and older versions.
     """
-    from .client import _ROCKY_VERSION
+    from ansys.rocky.core.client import _ROCKY_API, _get_numerical_version
 
+    ROCKY_VERSION = _get_numerical_version(_ROCKY_API)
     serialized = ApiElementProxy.serialize(obj)
 
-    if _ROCKY_VERSION is not None and _ROCKY_VERSION < 250:
+    if ROCKY_VERSION is not None and ROCKY_VERSION < 250:
         serialized["__class__"] = f'_{serialized["__class__"]}'
     return serialized
 

--- a/tests/test_pyrocky.py
+++ b/tests/test_pyrocky.py
@@ -76,14 +76,13 @@ def test_minimal_simulation(version, expected_version, tmp_path, request):
     """
     short_v = version.replace(".", "")
     exe_file = f"C:\\Program Files\\ANSYS Inc\\v{short_v}\\Rocky\\bin\\Rocky.exe"
-    pyrocky.launch_rocky(exe_file)
-    rocky = pyrocky.connect_to_rocky()
+    rocky = pyrocky.launch_rocky(exe_file)
     request.addfinalizer(rocky.close)
 
-    from ansys.rocky.core.client import _ROCKY_VERSION
+    from ansys.rocky.core.client import _ROCKY_API, _get_numerical_version
 
-    global _ROCKY_VERSION
-    assert _ROCKY_VERSION == expected_version
+    ROCKY_VERSION = _get_numerical_version(_ROCKY_API)
+    assert ROCKY_VERSION == expected_version
 
     study = create_basic_project_with_results(
         rocky.api, str(tmp_path / "rocky-testing.rocky")
@@ -105,8 +104,7 @@ def test_minimal_simulation(version, expected_version, tmp_path, request):
 
 def test_sequences_interface(rocky_session):
     """Ensure that API objects that are sequences have their dunder methods exposed."""
-    rocky = pyrocky.connect_to_rocky()
-    project = rocky.api.CreateProject()
+    project = rocky_session.api.CreateProject()
 
     study = project.GetStudy()
 
@@ -128,9 +126,8 @@ def test_sequences_interface(rocky_session):
 
 
 def test_export_toolkit(rocky_session, tmp_path):
-    rocky = pyrocky.connect_to_rocky()
     study = create_basic_project_with_results(
-        rocky.api,
+        rocky_session.api,
         str(tmp_path / "rocky-testing-export.rocky"),
         simulation_duration=0.1,
         time_interval=0.1,


### PR DESCRIPTION
The code was trying to update the `_ROCKY_VERSION` variable before the Rocky's process was raised. The solution was to use a function to return the version in every place that it is required, instead of saving it inside a variable. 