### PR TITLE
Make instructions to install "requests" more visible in the docs

### DIFF
--- a/examples/README.txt
+++ b/examples/README.txt
@@ -4,7 +4,12 @@
 Examples
 ========
 
-End-to-end examples show how to use PyRocky. You can download these examples as Python files or Jupyter notebooks
-and run them locally. Make sure to add 'requests' library to your environment (`pip install requests`) in order to
-download examples data at runtime.
+End-to-end examples show how to use PyRocky. You can download these examples as Python files or
+Jupyter notebooks and run them locally.
+
+Ensure that the **requests** library is installed in your Python environment in order to download
+examples data at runtime::
+
+    pip install requests
+
 


### PR DESCRIPTION
Instructions explaining that the "requests" library is required and must be installed separately were not noticeable enough. This moves the instruction to a new paragraph to make them more evident.

Fix #119

![image](https://github.com/user-attachments/assets/43dd0094-8d21-4e09-b724-77ff40616be9)
