### PR TITLE
Use ansys-tools-path to find Rocky exe path

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           .\.venv\Scripts\Activate.ps1
           python -m pip install --upgrade pip
-          pip install .[test]
+          pip install .[tests]
 
       - name: "Run unit tests"
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 tests = [
     "pytest==8.3.3",
     "pytest-cov==6.0.0",
+    "requests==2.32.3",
 ]
 doc = [
     "ansys-sphinx-theme==1.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "ansys-rocky-core"
-version = "0.2.dev0"
+version = "0.3.dev0"
 authors = [{ name="ANSYS, Inc.", email="pyansys.core@ansys.com" }]
 description = "Python client library for Ansys Rocky"
 readme = "README.rst"
@@ -25,6 +25,7 @@ dependencies = [
     "importlib-metadata>=4.0",
     "Pyro5>=5.13",
     "numpy>=1.19, <3.0",
+    "ansys-tools-path",
 ]
 
 [project.optional-dependencies]

--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -101,7 +101,7 @@ def launch_rocky(
                 raise FileNotFoundError("Rocky executable is not found.")
         else:
             if rocky_version < MINIMUM_ANSYS_VERSION_SUPPORTED:
-                raise ValueError(  # pragma: no cover
+                raise ValueError(
                     f"Rocky version {rocky_version} is not supported. "
                     f"The minimum supported version is {MINIMUM_ANSYS_VERSION_SUPPORTED}"
                 )
@@ -116,7 +116,7 @@ def launch_rocky(
                 raise FileNotFoundError(
                     f"Rocky executable for version {rocky_version} is not found."
                 )
-    elif isinstance(rocky_exe, str):  # pragma: no cover
+    elif isinstance(rocky_exe, str):
         rocky_exe = Path(rocky_exe)
         if not rocky_exe.is_file():
             raise FileNotFoundError(f"Rocky executable is not found at {rocky_exe}.")

--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -97,7 +97,9 @@ def launch_rocky(
                 ):
                     break
             else:
-                raise FileNotFoundError("Rocky executable is not found.")  # pragma: no cover
+                raise FileNotFoundError(
+                    "Rocky executable is not found."
+                )  # pragma: no cover
         else:
             if isinstance(rocky_version, str):
                 rocky_version = int(rocky_version)

--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -87,8 +87,13 @@ def launch_rocky(
     if rocky_exe is None:
         if rocky_version is None:
             for installation in sorted(ansys_installations, reverse=True):
-                rocky_exe = Path(ansys_installations[installation]) / "Rocky/bin/Rocky.exe"
-                if rocky_exe.is_file() and installation >= MINIMUM_ANSYS_VERSION_SUPPORTED:
+                rocky_exe = (
+                    Path(ansys_installations[installation]) / "Rocky/bin/Rocky.exe"
+                )
+                if (
+                    rocky_exe.is_file()
+                    and installation >= MINIMUM_ANSYS_VERSION_SUPPORTED
+                ):
                     break
             else:
                 raise FileNotFoundError("Rocky executable is not found.")

--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -54,8 +54,9 @@ def launch_rocky(
     rocky_exe:
         Path to the Rocky executable.
     rocky_version:
-        Rocky version to run. If no executable is passed and the version is not specified, this
-        method tries to find the path using the latest Ansys path returned by ansys-tools-path API.
+        Rocky version to run. If no executable is passed and the version is not
+        specified, this method tries to find the path using the latest Ansys path
+        returned by ansys-tools-path API.
     headless:
         Whether to launch Rocky in headless mode. The default is ``True``.
     server_port:

--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -121,6 +121,8 @@ def launch_rocky(
                 )
     elif isinstance(rocky_exe, str):
         rocky_exe = Path(rocky_exe)
+        if not rocky_exe.is_file():
+            raise FileNotFoundError(f"Rocky executable is not found at {rocky_exe}.")
 
     cmd = [rocky_exe, "--pyrocky", "--pyrocky-port", str(server_port)]
     if headless:

--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -97,13 +97,13 @@ def launch_rocky(
                 ):
                     break
             else:
-                raise FileNotFoundError("Rocky executable is not found.")
+                raise FileNotFoundError("Rocky executable is not found.")  # pragma: no cover
         else:
             if isinstance(rocky_version, str):
                 rocky_version = int(rocky_version)
 
             if rocky_version < MINIMUM_ANSYS_VERSION_SUPPORTED:
-                raise ValueError(
+                raise ValueError(  # pragma: no cover
                     f"Rocky version {rocky_version} is not supported. "
                     f"The minimum supported version is {MINIMUM_ANSYS_VERSION_SUPPORTED}"
                 )
@@ -111,16 +111,16 @@ def launch_rocky(
             if rocky_version in ansys_installations:
                 ansys_installation = ansys_installations.get(rocky_version)
             else:
-                raise FileNotFoundError(
+                raise FileNotFoundError(  # pragma: no cover
                     f"Rocky executable for version {rocky_version} is not found."
                 )
 
             rocky_exe = Path(ansys_installation) / "Rocky/bin/Rocky.exe"
             if not rocky_exe.is_file():
-                raise FileNotFoundError(
+                raise FileNotFoundError(  # pragma: no cover
                     f"Rocky executable for version {rocky_version} is not found."
                 )
-    elif isinstance(rocky_exe, str):
+    elif isinstance(rocky_exe, str):  # pragma: no cover
         rocky_exe = Path(rocky_exe)
         if not rocky_exe.is_file():
             raise FileNotFoundError(f"Rocky executable is not found at {rocky_exe}.")

--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -24,6 +24,7 @@ import contextlib
 from pathlib import Path
 import subprocess
 import time
+from typing import Optional, Union
 
 from Pyro5.errors import CommunicationError
 from ansys.tools.path import get_available_ansys_installations
@@ -36,8 +37,8 @@ MINIMUM_ANSYS_VERSION_SUPPORTED = 242
 
 
 def launch_rocky(
-    rocky_exe: Path | str = None,
-    rocky_version: str | int = None,
+    rocky_exe: Optional[Union[Path, str]] = None,
+    rocky_version: Optional[int] = None,
     *,
     headless: bool = True,
     server_port: int = DEFAULT_SERVER_PORT,
@@ -96,14 +97,11 @@ def launch_rocky(
                     and installation >= MINIMUM_ANSYS_VERSION_SUPPORTED
                 ):
                     break
-            else:
+            else:  # pragma: no cover
                 raise FileNotFoundError(
                     "Rocky executable is not found."
-                )  # pragma: no cover
+                )
         else:
-            if isinstance(rocky_version, str):
-                rocky_version = int(rocky_version)
-
             if rocky_version < MINIMUM_ANSYS_VERSION_SUPPORTED:
                 raise ValueError(  # pragma: no cover
                     f"Rocky version {rocky_version} is not supported. "
@@ -112,14 +110,12 @@ def launch_rocky(
 
             if rocky_version in ansys_installations:
                 ansys_installation = ansys_installations.get(rocky_version)
-            else:
-                raise FileNotFoundError(  # pragma: no cover
-                    f"Rocky executable for version {rocky_version} is not found."
-                )
+            else:  # pragma: no cover
+                raise FileNotFoundError("Rocky executable is not found.")
 
             rocky_exe = Path(ansys_installation) / "Rocky/bin/Rocky.exe"
-            if not rocky_exe.is_file():
-                raise FileNotFoundError(  # pragma: no cover
+            if not rocky_exe.is_file():  # pragma: no cover
+                raise FileNotFoundError(
                     f"Rocky executable for version {rocky_version} is not found."
                 )
     elif isinstance(rocky_exe, str):  # pragma: no cover

--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -98,9 +98,7 @@ def launch_rocky(
                 ):
                     break
             else:  # pragma: no cover
-                raise FileNotFoundError(
-                    "Rocky executable is not found."
-                )
+                raise FileNotFoundError("Rocky executable is not found.")
         else:
             if rocky_version < MINIMUM_ANSYS_VERSION_SUPPORTED:
                 raise ValueError(  # pragma: no cover

--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -21,14 +21,13 @@
 # SOFTWARE.
 """Module that exposes functions to launch a Rocky application session."""
 import contextlib
-
 from pathlib import Path
 import subprocess
 import time
 
 from Pyro5.errors import CommunicationError
-
 from ansys.tools.path import get_available_ansys_installations
+
 from ansys.rocky.core.client import DEFAULT_SERVER_PORT, RockyClient, connect_to_rocky
 from ansys.rocky.core.exceptions import RockyLaunchError
 
@@ -102,11 +101,15 @@ def launch_rocky(
         if rocky_version in ansys_installations:
             ansys_installation = ansys_installations.get(rocky_version)
         else:
-            raise FileNotFoundError(f"Rocky executable for version {rocky_version} is not found.")
+            raise FileNotFoundError(
+                f"Rocky executable for version {rocky_version} is not found."
+            )
 
         rocky_exe = Path(ansys_installation) / "Rocky/bin/Rocky.exe"
         if not rocky_exe.is_file():
-            raise FileNotFoundError(f"Rocky executable for version {rocky_version} is not found.")
+            raise FileNotFoundError(
+                f"Rocky executable for version {rocky_version} is not found."
+            )
 
     cmd = [rocky_exe, "--pyrocky", "--pyrocky-port", str(server_port)]
     if headless:

--- a/tests/test_pyrocky.py
+++ b/tests/test_pyrocky.py
@@ -66,8 +66,8 @@ def create_basic_project_with_results(
 @pytest.mark.parametrize(
     "version, expected_version",
     [
-        ("251", 251),
-        ("242", 240),
+        (251, 251),
+        (242, 240),
     ],
 )
 def test_minimal_simulation(version, expected_version, tmp_path, request):

--- a/tests/test_pyrocky.py
+++ b/tests/test_pyrocky.py
@@ -66,17 +66,15 @@ def create_basic_project_with_results(
 @pytest.mark.parametrize(
     "version, expected_version",
     [
-        ("25.1", 251),
-        ("24.2", 240),
+        ("251", 251),
+        ("242", 240),
     ],
 )
 def test_minimal_simulation(version, expected_version, tmp_path, request):
     """Minimal test to be run with all the supported Rocky version to ensure
     minimal backwards compatibility.
     """
-    short_v = version.replace(".", "")
-    exe_file = f"C:\\Program Files\\ANSYS Inc\\v{short_v}\\Rocky\\bin\\Rocky.exe"
-    rocky = pyrocky.launch_rocky(exe_file)
+    rocky = pyrocky.launch_rocky(rocky_version=version)
     request.addfinalizer(rocky.close)
 
     from ansys.rocky.core.client import _ROCKY_API, _get_numerical_version

--- a/tests/test_pyrocky.py
+++ b/tests/test_pyrocky.py
@@ -63,6 +63,27 @@ def create_basic_project_with_results(
     return study
 
 
+def test_not_supported_version_error():
+    with pytest.raises(ValueError, match="Rocky version 222 is not supported.*"):
+        pyrocky.launch_rocky(rocky_version=222)
+
+
+def test_rocky_exe_parameter():
+    from ansys.rocky.core.client import RockyClient
+
+    exe_file = "C:\\Program Files\\ANSYS Inc\\v251\\Rocky\\bin\\Rocky.exe"
+    rocky = pyrocky.launch_rocky(rocky_exe=exe_file)
+
+    assert isinstance(rocky, RockyClient)
+
+    rocky.close()
+
+
+def test_invalid_rocky_exe_parameter():
+    with pytest.raises(FileNotFoundError, match=f"Rocky executable is not found at*"):
+        pyrocky.launch_rocky(rocky_exe="C:\\Folder\\Rocky.exe")
+
+
 @pytest.mark.parametrize(
     "version, expected_version",
     [


### PR DESCRIPTION
* Add `ansys-tools-path` to our dependencies and use it to find Rocky exe path
* Define a minimum Ansys supported version and add some checks
* Bump version to `0.3.dev0` in .toml file