### PR TITLE
Add minimum version supported to the docs

### DIFF
--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -62,3 +62,9 @@ When the Rocky session is started in this way, you can connect to it with PyRock
     import ansys.rocky.core as pyrocky
 
     rocky = pyrocky.connect_to_rocky()
+
+Rocky Installation
+------------------------------
+
+To benefit fully from using PyRocky, you must have a licensed copy of Ansys Rocky
+installed. The minimum Rocky version supported by PyRocky is 2024 R2.

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -64,7 +64,7 @@ When the Rocky session is started in this way, you can connect to it with PyRock
     rocky = pyrocky.connect_to_rocky()
 
 Rocky Installation
-------------------------------
+------------------
 
 To benefit fully from using PyRocky, you must have a licensed copy of Ansys Rocky
 installed. The minimum Rocky version supported by PyRocky is 2024 R2.


### PR DESCRIPTION
Add a minimum Rocky version supported by PyRocky to the docs