### PR TITLE
Fix accepted licenses check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "Pyro5>=5.13",
     "numpy>=1.19, <3.0",
     "ansys-tools-path",
+    "click==8.1.3",  # clink 8.2.0 is failing the license check.
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
New click ver. 8.2.0 is failing the accepted license check. For now, just pin it to ver. 8.1.3.