### PR TITLE
Add pyrocky support to manage multiple application instances

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  workflow_dispatch:
   pull_request:
   push:
     tags:
@@ -78,13 +79,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
 
-  tests_setup:
-    name: Tests Setup
+  tests_setup_windows:
+    name: Windows Tests Setup
     runs-on: [self-hosted, Windows, pyrocky]
     if: |
       !contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
       !contains(github.event.pull_request.labels.*.name, 'tests:skip')
-    timeout-minutes: 10
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v4
@@ -98,15 +99,15 @@ jobs:
         run: |
           python -m venv .venv
 
-      - name: Install packages for tests
+      - name: Install packages for tests (Windows)
         run: |
           .\.venv\Scripts\Activate.ps1
           python -m pip install --upgrade pip
           pip install .[tests]
 
-  tests_run:
-    name: Tests
-    needs: tests_setup
+  tests_run_windows:
+    name: Windows Tests
+    needs: tests_setup_windows
     runs-on: [self-hosted, Windows, pyrocky]
     if: |
       !contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
@@ -115,12 +116,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ansys-version: [242, 251, 252, 261]
+        ansys-version: [251, 252, 261]
     env:
       ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
 
     steps:
-      - name: "Run unit tests"
+      - name: Run unit tests (Windows)
         env:
           ANSYS_VERSION: ${{ matrix.ansys-version }}
         run: |
@@ -134,6 +135,59 @@ jobs:
         with:
           files: .cov/xml
           flags: ${{ matrix.ansys-version }}
+
+  tests_setup_linux:
+    name: Linux Tests Setup
+    runs-on: [self-hosted, Linux, pyrocky]
+    # Temporarily disable Linux setup and tests
+    if: |
+      false &&
+      !contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
+      !contains(github.event.pull_request.labels.*.name, 'tests:skip')
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+
+      - name: Create Python venv
+        run: |
+          python -m venv .venv
+
+      - name: Install packages for tests (Linux)
+        run: |
+          source .venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install .[tests]
+
+  tests_run_linux:
+    name: Linux v${{ matrix.ansys-version }} Tests
+    needs: tests_setup_linux
+    runs-on: [self-hosted, Linux, pyrocky]
+    # Temporarily disable Linux setup and tests
+    if: |
+      false &&
+      !contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
+      !contains(github.event.pull_request.labels.*.name, 'tests:skip')
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        ansys-version: [251, 252, 261]
+    env:
+      ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
+
+    steps:
+      - name: Run unit tests (Linux)
+        env:
+          ANSYS_VERSION: ${{ matrix.ansys-version }}
+        run: |
+          source .venv/bin/activate
+          pytest tests
 
   docs_build:
     name: Build Documentation
@@ -187,7 +241,7 @@ jobs:
 
   package:
     name: Package library
-    needs: [tests_run, docs_build]
+    needs: [tests_run_windows, docs_build]
     runs-on: ubuntu-latest
     if: |
       !contains(github.event.pull_request.labels.*.name, 'ci:skip')

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -115,7 +115,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ansys-version: [242, 251, 252]
+        ansys-version: [242, 251, 252, 261]
     env:
       ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
 

--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -29,7 +29,7 @@ import time
 from Pyro5.errors import CommunicationError
 from ansys.tools.path import get_available_ansys_installations
 
-from ansys.rocky.core.client import DEFAULT_SERVER_PORT, RockyClient, connect
+from ansys.rocky.core.client import PYROCKY_DEFAULT_PORT, RockyClient, connect
 from ansys.rocky.core.exceptions import FreeflowLaunchError, RockyLaunchError
 
 MINIMUM_ANSYS_VERSION_SUPPORTED = 242
@@ -41,7 +41,7 @@ def launch_rocky(
     rocky_version: int | None = None,
     *,
     headless: bool = True,
-    server_port: int = DEFAULT_SERVER_PORT,
+    server_port: int = PYROCKY_DEFAULT_PORT,
     close_existing: bool = False,
 ) -> RockyClient:
     """
@@ -121,7 +121,7 @@ def launch_freeflow(  # pragma: no cover
     freeflow_version: int | None = None,
     *,
     headless: bool = True,
-    server_port: int = DEFAULT_SERVER_PORT,
+    server_port: int = PYROCKY_DEFAULT_PORT,
     close_existing: bool = False,
 ) -> RockyClient:
     """

--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -244,7 +244,7 @@ def _find_executable(
     """
     if sys.platform == "win32":
         if version is not None:
-            if product_name == "Rocky":
+            if product_name == "Rocky" or version >= 261:
                 version = f"{version // 10}.{version % 10}.0"
             else:
                 version = f"{version // 10}.{version % 10}.0-BETA"

--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -29,7 +29,7 @@ import time
 from Pyro5.errors import CommunicationError
 from ansys.tools.path import get_available_ansys_installations
 
-from ansys.rocky.core.client import PYROCKY_DEFAULT_PORT, RockyClient, connect
+from ansys.rocky.core.client import _PYROCKY_DEFAULT_PORT, RockyClient, connect
 from ansys.rocky.core.exceptions import FreeflowLaunchError, RockyLaunchError
 
 MINIMUM_ANSYS_VERSION_SUPPORTED = 242
@@ -41,7 +41,7 @@ def launch_rocky(
     rocky_version: int | None = None,
     *,
     headless: bool = True,
-    server_port: int = PYROCKY_DEFAULT_PORT,
+    server_port: int = _PYROCKY_DEFAULT_PORT,
     close_existing: bool = False,
 ) -> RockyClient:
     """
@@ -121,7 +121,7 @@ def launch_freeflow(  # pragma: no cover
     freeflow_version: int | None = None,
     *,
     headless: bool = True,
-    server_port: int = PYROCKY_DEFAULT_PORT,
+    server_port: int = _PYROCKY_DEFAULT_PORT,
     close_existing: bool = False,
 ) -> RockyClient:
     """

--- a/src/ansys/rocky/core/rocky_api_proxies.py
+++ b/src/ansys/rocky/core/rocky_api_proxies.py
@@ -40,9 +40,10 @@ class ApiElementProxy:
         ID of the API element.
     """
 
-    def __init__(self, pyro_api: Pyro5.api.Proxy, pool_id: str) -> None:
+    def __init__(self, pyro_api: Pyro5.api.Proxy, pool_id: str, session_uid: str | None = None) -> None:
         self._pyro_api = pyro_api
         self._pool_id = pool_id
+        self._session_uid = session_uid
 
     def __getattr__(self, attr_name: str) -> object:
         def CallProxy(*args: tuple, **kwargs: dict) -> Any:
@@ -66,7 +67,11 @@ class ApiElementProxy:
         dict
             Dictionary of the serialized object.
         """
-        return {"__class__": obj.__class__.__name__, "_api_element_id": obj._pool_id}
+        return {
+            "__class__": obj.__class__.__name__,
+            "_api_element_id": obj._pool_id,
+            "_session_uid": obj._session_uid if obj._session_uid is not None else None,
+        }
 
 
 class ApiListProxy(ApiElementProxy):
@@ -88,11 +93,16 @@ class ApiListProxy(ApiElementProxy):
 
 class ApiGridFunctionProxy:
     def __init__(
-        self, grid_pool_id: str, gf_name: str, pyro_api: Pyro5.api.Proxy
+        self,
+        grid_pool_id: str,
+        gf_name: str,
+        pyro_api: Pyro5.api.Proxy,
+        session_uid: str | None = None,
     ) -> None:
         self._grid_pool_id = grid_pool_id
         self._gf_name = gf_name
         self._pyro_api = pyro_api
+        self._session_uid = session_uid
 
     def __getattr__(self, attr_name: str) -> Callable:
         def CallProxy(*args: tuple, **kwargs: dict) -> Any:
@@ -120,12 +130,14 @@ class ApiGridFunctionProxy:
             "__class__": cls.__name__,
             "grid_pool_id": obj._grid_pool_id,
             "gf_name": obj._gf_name,
+            "_session_uid": obj._session_uid if obj._session_uid is not None else None,
         }
 
 
 class ApiExportToolkitProxy:
-    def __init__(self, pyro_api: Pyro5.api.Proxy) -> None:
+    def __init__(self, pyro_api: Pyro5.api.Proxy, session_uid: str | None = None) -> None:
         self._pyro_api = pyro_api
+        self._session_uid = session_uid
 
     def __getattr__(self, attr_name: str) -> Callable:
         def CallProxy(*args: tuple, **kwargs: dict) -> Any:
@@ -149,4 +161,7 @@ class ApiExportToolkitProxy:
         dict
             Dictionary of the serialized object.
         """
-        return {"__class__": cls.__name__}
+        return {
+            "__class__": cls.__name__,
+            "_session_uid": obj._session_uid if obj._session_uid is not None else None,
+        }

--- a/src/ansys/rocky/core/serializers.py
+++ b/src/ansys/rocky/core/serializers.py
@@ -61,7 +61,8 @@ def _ApiElementProxySerializer(obj: ApiElementProxy) -> dict:
 
     serialized = ApiElementProxy.serialize(obj)
     session_uid = serialized.get("_session_uid")
-    proxy = ROCKY_API_PROXIES.get(session_uid, OLD_VERSION_PROXY_KEY)
+    old_version_proxy = ROCKY_API_PROXIES.get(OLD_VERSION_PROXY_KEY)
+    proxy = ROCKY_API_PROXIES.get(session_uid, old_version_proxy)
     rocky_version = _get_numerical_version(proxy)
 
     if rocky_version is not None:

--- a/src/ansys/rocky/core/serializers.py
+++ b/src/ansys/rocky/core/serializers.py
@@ -55,15 +55,21 @@ def register_proxies() -> None:
 def _ApiElementProxySerializer(obj: ApiElementProxy) -> dict:
     """
     Serialize an `ApiElementProxy` ensuring backward compatibility with
-    ROCKY 24.2 and older versions.
+    ROCKY 25.2 and older versions.
     """
-    from ansys.rocky.core.client import _ROCKY_API, _get_numerical_version
+    from .client import ROCKY_API_PROXIES, OLD_VERSION_PROXY_KEY, _get_numerical_version
 
-    ROCKY_VERSION = _get_numerical_version(_ROCKY_API)
     serialized = ApiElementProxy.serialize(obj)
+    session_uid = serialized.get("_session_uid")
+    proxy = ROCKY_API_PROXIES.get(session_uid, OLD_VERSION_PROXY_KEY)
+    rocky_version = _get_numerical_version(proxy)
 
-    if ROCKY_VERSION is not None and ROCKY_VERSION < 250:
-        serialized["__class__"] = f'_{serialized["__class__"]}'
+    if rocky_version is not None:
+        if rocky_version < 250:
+            serialized["__class__"] = f'_{serialized["__class__"]}'
+        if rocky_version < 261 and "_session_uid" in serialized:
+            del serialized["_session_uid"]
+
     return serialized
 
 
@@ -83,10 +89,14 @@ def deserialize_api_element(classname: str, serialized: dict) -> ApiElementProxy
     ApiElementProxy
         Deserialized object.
     """
-    from .client import _ROCKY_API
+    from .client import ROCKY_API_PROXIES, OLD_VERSION_PROXY_KEY
 
-    assert _ROCKY_API is not None, "API Proxy not initialized"
-    return ApiElementProxy(_ROCKY_API, serialized["_api_element_id"])
+    session_uid = serialized.get("_session_uid")
+    old_version_proxy = ROCKY_API_PROXIES.get(OLD_VERSION_PROXY_KEY)
+    proxy = ROCKY_API_PROXIES.get(session_uid, old_version_proxy)
+    assert proxy is not None, "API Proxy not initialized"
+
+    return ApiElementProxy(proxy, serialized["_api_element_id"], session_uid)
 
 
 def deserialize_api_list(classname: str, serialized: dict) -> ApiListProxy:
@@ -105,10 +115,14 @@ def deserialize_api_list(classname: str, serialized: dict) -> ApiListProxy:
     ApiListProxy
         Deserialized object.
     """
-    from .client import _ROCKY_API
+    from .client import ROCKY_API_PROXIES, OLD_VERSION_PROXY_KEY
 
-    assert _ROCKY_API is not None, "API Proxy not initialized"
-    return ApiListProxy(_ROCKY_API, serialized["_api_element_id"])
+    session_uid = serialized.get("_session_uid")
+    old_version_proxy = ROCKY_API_PROXIES.get(OLD_VERSION_PROXY_KEY)
+    proxy = ROCKY_API_PROXIES.get(session_uid, old_version_proxy)
+    assert proxy is not None, "API Proxy not initialized"
+
+    return ApiListProxy(proxy, serialized["_api_element_id"], session_uid)
 
 
 def deserialize_api_grid_function(
@@ -129,11 +143,18 @@ def deserialize_api_grid_function(
     ApiGridFunctionProxy
         Deserialized object.
     """
-    from .client import _ROCKY_API
+    from .client import ROCKY_API_PROXIES, OLD_VERSION_PROXY_KEY
 
-    assert _ROCKY_API is not None, "API Proxy not initialized"
+    session_uid = serialized.get("_session_uid")
+    old_version_proxy = ROCKY_API_PROXIES.get(OLD_VERSION_PROXY_KEY)
+    proxy = ROCKY_API_PROXIES.get(session_uid, old_version_proxy)
+    assert proxy is not None, "API Proxy not initialized"
+
     return ApiGridFunctionProxy(
-        serialized["grid_pool_id"], serialized["gf_name"], _ROCKY_API
+        serialized["grid_pool_id"],
+        serialized["gf_name"],
+        proxy,
+        session_uid,
     )
 
 
@@ -155,10 +176,14 @@ def deserialize_api_exporttoolkit(
     ApiExportToolkitProxy
         Deserialized object.
     """
-    from .client import _ROCKY_API
+    from .client import ROCKY_API_PROXIES, OLD_VERSION_PROXY_KEY
 
-    assert _ROCKY_API is not None, "API Proxy not initialized"
-    return ApiExportToolkitProxy(_ROCKY_API)
+    session_uid = serialized.get("_session_uid")
+    old_version_proxy = ROCKY_API_PROXIES.get(OLD_VERSION_PROXY_KEY)
+    proxy = ROCKY_API_PROXIES.get(session_uid, old_version_proxy)
+    assert proxy is not None, "API Proxy not initialized"
+
+    return ApiExportToolkitProxy(proxy, session_uid)
 
 
 def deserialize_api_error(classname: str, serialized: dict) -> Exception:

--- a/tests/test_pyrocky.py
+++ b/tests/test_pyrocky.py
@@ -19,19 +19,20 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import hashlib
 import os
 
 import pytest
 
 import ansys.rocky.core as pyrocky
-from ansys.rocky.core.client import DEFAULT_SERVER_PORT
+from ansys.rocky.core.client import PYROCKY_DEFAULT_PORT
 from ansys.rocky.core.exceptions import PyRockyError
 from ansys.rocky.core.launcher import RockyLaunchError
 from ansys.rocky.core.rocky_api_proxies import ApiExportToolkitProxy
 
-VERSION = int(os.getenv("ANSYS_VERSION", "252"))
+VERSION = int(os.getenv("ANSYS_VERSION", "261"))
 
-FREEFLOW_VERSION = 251
+FREEFLOW_VERSION = 261
 
 
 @pytest.fixture()
@@ -107,17 +108,17 @@ def test_minimal_simulation(tmp_path, request):
     """Minimal test to be run with all the supported Rocky version to ensure
     minimal backwards compatibility.
     """
+    from ansys.rocky.core.client import ROCKY_API_PROXIES, _get_numerical_version
     rocky = pyrocky.launch_rocky(rocky_version=VERSION)
     request.addfinalizer(rocky.close)
-
-    from ansys.rocky.core.client import _ROCKY_API, _get_numerical_version
 
     if VERSION < 251:
         expected_rocky_version = 240
     else:
         expected_rocky_version = VERSION
 
-    rocky_version = _get_numerical_version(_ROCKY_API)
+    session_uid = hashlib.md5(f"localhost:{PYROCKY_DEFAULT_PORT}".encode()).hexdigest()
+    rocky_version = _get_numerical_version(ROCKY_API_PROXIES[session_uid])
     assert rocky_version == expected_rocky_version
 
     study = create_basic_project_with_results(
@@ -187,7 +188,7 @@ def test_pyrocky_launch_multiple_servers():
 
     # Emulating Rocky server already running by binding socket to the server address.
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("localhost", DEFAULT_SERVER_PORT))
+        s.bind(("localhost", PYROCKY_DEFAULT_PORT))
         s.listen(10)
 
         with pytest.raises(RockyLaunchError, match=r"Port \d+ is already in use"):
@@ -249,10 +250,11 @@ def test_freeflow_launcher_with_specified_version(request):
     freeflow = pyrocky.launch_freeflow(freeflow_version=FREEFLOW_VERSION)
     request.addfinalizer(freeflow.close)
 
-    from ansys.rocky.core.client import _ROCKY_API, _get_numerical_version
+    from ansys.rocky.core.client import ROCKY_API_PROXIES, _get_numerical_version
 
-    ROCKY_VERSION = _get_numerical_version(_ROCKY_API)
-    assert ROCKY_VERSION == FREEFLOW_VERSION
+    session_uid = hashlib.md5(f"localhost:{PYROCKY_DEFAULT_PORT}".encode()).hexdigest()
+    freeflow_version = _get_numerical_version(ROCKY_API_PROXIES[session_uid])
+    assert freeflow_version == FREEFLOW_VERSION
 
 
 def test_no_valid_local_winreg_exe():
@@ -269,9 +271,9 @@ def test_connection_check(request, monkeypatch):
     ):
         with monkeypatch.context() as m:
             m.setattr(client, "_CONNECT_TO_SERVER_TIMEOUT", 0)
-            pyrocky.launch_rocky(server_port=DEFAULT_SERVER_PORT)
+            pyrocky.launch_rocky(server_port=PYROCKY_DEFAULT_PORT)
 
-    cli = pyrocky.connect(port=DEFAULT_SERVER_PORT)
+    cli = pyrocky.connect(port=PYROCKY_DEFAULT_PORT)
     request.addfinalizer(cli.close)
 
     assert cli.api._pyroConnection


### PR DESCRIPTION
Now PyRocky will give support to manage multiple Rocky instances within the same PyRocky instance. We will be able to do something like:

rocky1 = pyrocky.connect(port=19000)
project1 = rocky1.api.CreateProject()

rocky2 = pyrocky.connect(port=19001)
project2 = rocky2.api.CreateProject()

study1 = project1.GetStudy()
study2 = project2.GetStudy()

The mechanism is simple: Store the Pyro Proxy object in a dictionary in relation to a tuple of host and port values. However, in order to access the correct dict key inserting the port and hostname, we needed to expose these values on the rocky side (as a parameter of the entities proxies), so we can properly access them from the PyRocky side.

Each client will access its own pyro proxy and use it during any serialization or deserialization.