### PR TITLE
Handle project save state from client side when closing

### DIFF
--- a/src/ansys/rocky/core/rocky_api_proxies.py
+++ b/src/ansys/rocky/core/rocky_api_proxies.py
@@ -165,3 +165,16 @@ class ApiExportToolkitProxy:
             "__class__": cls.__name__,
             "_session_uid": obj._session_uid if obj._session_uid is not None else None,
         }
+
+
+class ApiProjectProxy(ApiElementProxy):
+    def __init__(self, pyro_api: Pyro5.api.Proxy, session_uid: str | None = None) -> None:
+        super().__init__(pyro_api, 'project', session_uid)
+
+    def CloseProject(self, check_save_state: bool = True) -> None:
+        if check_save_state and self.HasUnsavedChanges():
+            raise RuntimeError(
+                "Project has unsaved changes. Save the project before closing or use check_save_state=False."
+            )
+
+        self._pyro_api.SendToApiElement(self._pool_id, "CloseProject", check_save_state=check_save_state)

--- a/src/ansys/rocky/core/serializers.py
+++ b/src/ansys/rocky/core/serializers.py
@@ -34,6 +34,7 @@ from ansys.rocky.core.rocky_api_proxies import (
     ApiExportToolkitProxy,
     ApiGridFunctionProxy,
     ApiListProxy,
+    ApiProjectProxy,
 )
 
 
@@ -45,6 +46,9 @@ def register_proxies() -> None:
     )
     Pyro5.api.register_dict_to_class(
         "ApiExportToolkitProxy", deserialize_api_exporttoolkit
+    )
+    Pyro5.api.register_dict_to_class(
+        "ApiProjectProxy", deserialize_api_project
     )
     Pyro5.api.register_dict_to_class("RockyApiError", deserialize_api_error)
     Pyro5.api.register_dict_to_class("ndarray", deserialize_numpy)
@@ -168,6 +172,30 @@ def deserialize_api_exporttoolkit(
     proxy = _GetProxyInstance(session_uid)
 
     return ApiExportToolkitProxy(proxy, session_uid)
+
+
+def deserialize_api_project(
+    classname: str, serialized: dict
+) -> ApiProjectProxy:
+    """Deserialize the proxy objects for the API project.
+
+    Parameters
+    ----------
+    classname : str
+        Name of the class to deserialize. This parameter is required by the
+        superclass but is not used.
+    serialized : dict
+        Dictionary of serialized objects.
+
+    Returns
+    -------
+    ApiProjectProxy
+        Deserialized object.
+    """
+    session_uid = serialized.get("_session_uid")
+    proxy = _GetProxyInstance(session_uid)
+
+    return ApiProjectProxy(proxy, session_uid)
 
 
 def deserialize_api_error(classname: str, serialized: dict) -> Exception:


### PR DESCRIPTION
* Raise an error on the client side when closing a project with `check_save_state=True` and unsaved changes in the project