### PR TITLE
Fix release job not running when a new tag is pushed

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -194,7 +194,8 @@ jobs:
     runs-on: [self-hosted, Windows, pyrocky]
     if: |
       contains(github.event.pull_request.labels.*.name, 'docs') ||
-      github.ref == 'refs/heads/main'
+      github.ref == 'refs/heads/main' ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     env:
       ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
 


### PR DESCRIPTION
The conditions for the "Build Documentation" step was not being met when a new tag was pushed. That blocks the package step, and thus, the release step.