### PR TITLE
Fix Pyro TCP authentication failure on windows

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -122,6 +122,8 @@ jobs:
           - ansys-version: 261
     env:
       ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
+      # Windows TCP client authentication still doesn't support IPv6
+      PYRO_PREFER_IP_VERSION: 4
 
     steps:
       - name: Run unit tests (Windows)
@@ -201,6 +203,8 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     env:
       ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
+      # Windows TCP client authentication still doesn't support IPv6
+      PYRO_PREFER_IP_VERSION: 4
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
FPN library dll used in windows TCP authentication doesn't support IPv6. Tell pyro to prefer IPv4 for windows runs.