### PR TITLE
feat: Show remote tracebacks for server side errors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+Copyright (c) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/src/ansys/rocky/core/client.py
+++ b/src/ansys/rocky/core/client.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #
@@ -123,6 +123,10 @@ def connect(host: str | None = None, port: int = _PYROCKY_DEFAULT_PORT) -> "Rock
         _LEGACY_PROXY_INSTANCE = proxy_instance  # For backward compatibility
 
     rocky_client = RockyClient(proxy_instance)
+
+    # Install Pyro hook to automatically print remote error tracebacks.
+    sys.excepthook = Pyro5.errors.excepthook
+
     return rocky_client
 
 


### PR DESCRIPTION
Install pyro excepthook to show remote traceback when error happens server side.

See: https://pyro5.readthedocs.io/en/latest/errors.html#remote-exceptions

Example:
```
Traceback (most recent call last):
  File "D:\AnsysDev\fluids-one\Projects\pyrocky\examples\basic_examples\minimal.py", line 83, in <module>
    study.StartSimulation()
  File "D:\AnsysDev\fluids-one\Projects\pyrocky\src\ansys\rocky\core\rocky_api_proxies.py", line 50, in CallProxy
    return self._pyro_api.SendToApiElement(
  File "D:\AnsysDev\fluids-one\Projects\pyrocky\.venv\lib\site-packages\Pyro5\client.py", line 510, in __call__
    return self.__send(self.__name, args, kwargs)
  File "D:\AnsysDev\fluids-one\Projects\pyrocky\.venv\lib\site-packages\Pyro5\client.py", line 275, in _pyroInvoke
    raise data  # if you see this in your traceback, you should probably inspect the remote traceback as well
RuntimeError: An internal error occurred while executing StartSimulation: There is already a simulation running. Stop it or wait for it to finish.
 +--- This exception occured remotely (Pyro) - Remote traceback:
 | Traceback (most recent call last):
 |   File "D:\AnsysDev\1\Projects\rocky\rocky30\source\python\rocky30\plugins\pyrocky\api_pyro_adapter.py", line 108, in _SendToObject
 |     result = method(*args, **kwargs)
 |   File "D:\AnsysDev\1\Projects\rocky\rocky30\source\python\rocky30\plugins\api\ra_study.py", line 1241, in StartSimulation
 |     self._QuerySimulationService(
 |   File "D:\AnsysDev\1\Projects\rocky\rocky30\source\python\rocky30\plugins\api\ra_study.py", line 1038, in _QuerySimulationService
 |     return getattr(simulation_service, method_name)(*args, **kwargs)
 |   File "D:\AnsysDev\1\Projects\rocky\rocky30\source\python\rocky30\plugins\simulation\rocky_simulation.py", line 740, in StartSimulation
 |     raise SimulationProcessError(
 | rocky30.plugins.simulation.rocky_simulation.SimulationProcessError: There is already a simulation running. Stop it or wait for it to finish.
 | 
 | The above exception was the direct cause of the following exception:
 | 
 | Traceback (most recent call last):
 |   File "D:\AnsysDev\1\envs\rocky\lib\site-packages\Pyro5\server.py", line 471, in handleRequest
 |     data = method(*vargs, **kwargs)  # this is the actual method call to the Pyro object
 |   File "D:\AnsysDev\1\Projects\rocky\rocky30\source\python\rocky30\plugins\pyrocky\api_pyro_adapter.py", line 65, in SendToApiElement
 |     return self._SendToObject(api_element, message, *args, **kwargs)
 |   File "D:\AnsysDev\1\Projects\rocky\rocky30\source\python\rocky30\plugins\pyrocky\api_pyro_adapter.py", line 116, in _SendToObject
 |     raise RuntimeError(
 | RuntimeError: An internal error occurred while executing StartSimulation: There is already a simulation running. Stop it or wait for it to finish.
 +--- End of remote traceback
```