### PR TITLE
Reactivate test suite on Linux and move docs generation to Linux

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -138,14 +138,19 @@ jobs:
           files: .cov/xml
           flags: ${{ matrix.ansys-version }}
 
-  tests_setup_linux:
-    name: Linux Tests Setup
+  tests_run_linux:
+    name: Linux v${{ matrix.ansys-version }} Tests
     runs-on: [self-hosted, Linux, pyrocky]
-    # Temporarily disable Linux setup and tests
-#    if: |
-#      !contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
-#      !contains(github.event.pull_request.labels.*.name, 'tests:skip')
-    timeout-minutes: 5
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
+      !contains(github.event.pull_request.labels.*.name, 'tests:skip')
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        ansys-version: [261]
+    env:
+      ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
 
     steps:
       - uses: actions/checkout@v6
@@ -157,46 +162,21 @@ jobs:
 
       - name: Create Python venv
         run: |
-          python -m venv .venv-tests
-
-      - name: Install packages for tests (Linux)
-        run: |
-          source .venv-tests/bin/activate
+          python -m venv .venv
+          source .venv/bin/activate
           python -m pip install --upgrade pip
           pip install .[tests]
-
-  tests_run_linux:
-    name: Linux v${{ matrix.ansys-version }} Tests
-    needs: tests_setup_linux
-    runs-on: [self-hosted, Linux, pyrocky]
-    # Temporarily disable Linux setup and tests
-#    if: |
-#      !contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
-#      !contains(github.event.pull_request.labels.*.name, 'tests:skip')
-    timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        ansys-version: [261]
-    env:
-      ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
-
-    steps:
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
       - name: Run unit tests (Linux)
         env:
           ANSYS_VERSION: ${{ matrix.ansys-version }}
         run: |
-          source .venv-tests/bin/activate
-          pytest tests
+          source .venv/bin/activate
+          pytest tests -ra --cov=ansys.rocky --cov-report html:.cov/html --cov-report xml:.cov/xml --cov-report term -vv
 
   docs_build:
     name: Documentation
-    runs-on: [self-hosted, Windows, pyrocky]
+    runs-on: [self-hosted, Linux, pyrocky]
     if: |
       contains(github.event.pull_request.labels.*.name, 'docs') ||
       github.ref == 'refs/heads/main' ||
@@ -209,8 +189,7 @@ jobs:
         uses: ansys/actions/doc-build@v10
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
-          use-uv: false
-          use-python-cache: 'false'
+          use-uv: true
           # Disable default -W flag (treat warnings as errors)
           sphinxopts: '-j 1'
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -142,10 +142,9 @@ jobs:
     name: Linux Tests Setup
     runs-on: [self-hosted, Linux, pyrocky]
     # Temporarily disable Linux setup and tests
-    if: |
-      false &&
-      !contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
-      !contains(github.event.pull_request.labels.*.name, 'tests:skip')
+#    if: |
+#      !contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
+#      !contains(github.event.pull_request.labels.*.name, 'tests:skip')
     timeout-minutes: 5
 
     steps:
@@ -158,11 +157,11 @@ jobs:
 
       - name: Create Python venv
         run: |
-          python -m venv .venv
+          python -m venv .venv-tests
 
       - name: Install packages for tests (Linux)
         run: |
-          source .venv/bin/activate
+          source .venv-tests/bin/activate
           python -m pip install --upgrade pip
           pip install .[tests]
 
@@ -171,24 +170,28 @@ jobs:
     needs: tests_setup_linux
     runs-on: [self-hosted, Linux, pyrocky]
     # Temporarily disable Linux setup and tests
-    if: |
-      false &&
-      !contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
-      !contains(github.event.pull_request.labels.*.name, 'tests:skip')
+#    if: |
+#      !contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
+#      !contains(github.event.pull_request.labels.*.name, 'tests:skip')
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
-        ansys-version: [251, 252, 261]
+        ansys-version: [261]
     env:
       ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
 
     steps:
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+
       - name: Run unit tests (Linux)
         env:
           ANSYS_VERSION: ${{ matrix.ansys-version }}
         run: |
-          source .venv/bin/activate
+          source .venv-tests/bin/activate
           pytest tests
 
   docs_build:
@@ -200,8 +203,6 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     env:
       ANSYSLMD_LICENSE_FILE: 1055@${{ secrets.LICENSE_SERVER }}
-      # Windows TCP client authentication still doesn't support IPv6
-      PYRO_PREFER_IP_VERSION: 4
 
     steps:
       - name: Build Documentation

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -110,7 +110,6 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
-
 sphinx_gallery_conf = {
     # path to your examples scripts
     "examples_dirs": ["../../examples/"],
@@ -146,3 +145,7 @@ autoapi_render_in_single_page = ["class", "enum", "exception"]
 html_context = {"pyansys_tags": ["Fluids"]}
 
 suppress_warnings = ["autoapi.python_import_resolution", "config.cache"]
+# Do not check Ansys Rocky website since it takes a lot of time to fully load.
+linkcheck_ignore = [
+    "https://www.ansys.com/products/fluids/ansys-rocky",
+]

--- a/examples/basic_examples/minimal.py
+++ b/examples/basic_examples/minimal.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #
@@ -38,14 +38,11 @@ import tempfile
 
 import ansys.rocky.core as pyrocky
 
-# Temporarily pin to v252 because next version is failing on Pyro connection
-ROCKY_VERSION = 252
-
 # Create a temp directory to save the project.
 project_dir = tempfile.mkdtemp(prefix="pyrocky_")
 
 # Launch Rocky and open a project.
-rocky = pyrocky.launch_rocky(rocky_version=ROCKY_VERSION)
+rocky = pyrocky.launch_rocky()
 project = rocky.api.CreateProject()
 
 ###############################################################################

--- a/examples/basic_examples/particle_wall_interaction.py
+++ b/examples/basic_examples/particle_wall_interaction.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #
@@ -45,14 +45,11 @@ import tempfile
 import ansys.rocky.core as pyrocky
 from ansys.rocky.core import examples
 
-# Temporarily pin to v252 because next version is failing on Pyro connection
-ROCKY_VERSION = 252
-
 # Create a temp directory to save the project.
 project_dir = tempfile.mkdtemp(prefix="pyrocky_")
 
 # Launch Rocky and open a project.
-rocky = pyrocky.launch_rocky(rocky_version=ROCKY_VERSION)
+rocky = pyrocky.launch_rocky()
 project = rocky.api.CreateProject()
 project.SaveProject(os.path.join(project_dir, "rocky-testing.rocky"))
 

--- a/examples/basic_examples/particle_wall_interaction_with_motion.py
+++ b/examples/basic_examples/particle_wall_interaction_with_motion.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #
@@ -44,14 +44,11 @@ import tempfile
 import ansys.rocky.core as pyrocky
 from ansys.rocky.core import examples
 
-# Temporarily pin to v252 because next version is failing on Pyro connection
-ROCKY_VERSION = 252
-
 # Create a temp directory to save the project.
 project_dir = tempfile.mkdtemp(prefix="pyrocky_")
 
 # Launch Rocky and open a project.
-rocky = pyrocky.launch_rocky(rocky_version=ROCKY_VERSION)
+rocky = pyrocky.launch_rocky()
 project = rocky.api.CreateProject()
 project.SaveProject(os.path.join(project_dir, "rocky-testing.rocky"))
 

--- a/examples/basic_examples/start_simulation_async.py
+++ b/examples/basic_examples/start_simulation_async.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2025 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
 # SPDX-License-Identifier: MIT
 #
 #
@@ -48,14 +48,11 @@ import numpy as np
 import ansys.rocky.core as pyrocky
 from ansys.rocky.core import examples
 
-# Temporarily pin to v252 because next version is failing on Pyro connection
-ROCKY_VERSION = 252
-
 # Create a temp directory to save the project.
 project_dir = tempfile.mkdtemp(prefix="pyrocky_")
 
 # Launch Rocky and open a project.
-rocky = pyrocky.launch_rocky(rocky_version=ROCKY_VERSION)
+rocky = pyrocky.launch_rocky()
 project = rocky.api.CreateProject()
 project.SaveProject(os.path.join(project_dir, "rocky-testing.rocky"))
 

--- a/src/ansys/rocky/core/client.py
+++ b/src/ansys/rocky/core/client.py
@@ -39,7 +39,7 @@ from ansys.rocky.core.serializers import register_proxies
 if TYPE_CHECKING:
     from ansys.rocky.app.rocky_api_application import RockyApiApplication
 
-PYROCKY_DEFAULT_PORT: Final[int] = 9011
+PYROCKY_DEFAULT_PORT: Final[int] = 18615
 _API_PROXY_INSTANCES: dict[str, Pyro5.api.Proxy] = {}
 _LEGACY_PROXY_INSTANCE: Pyro5.api.Proxy | None = (
     None  # Used for backward compatibility with versions < 26.1

--- a/src/ansys/rocky/core/client.py
+++ b/src/ansys/rocky/core/client.py
@@ -39,7 +39,7 @@ from ansys.rocky.core.serializers import register_proxies
 if TYPE_CHECKING:
     from ansys.rocky.app.rocky_api_application import RockyApiApplication
 
-PYROCKY_DEFAULT_PORT: Final[int] = 18615
+PYROCKY_DEFAULT_PORT: Final[int] = 9011
 _API_PROXY_INSTANCES: dict[str, Pyro5.api.Proxy] = {}
 _LEGACY_PROXY_INSTANCE: Pyro5.api.Proxy | None = (
     None  # Used for backward compatibility with versions < 26.1

--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -26,12 +26,11 @@ import os
 from pathlib import Path
 import subprocess
 import sys
-import time
-from typing import Any, Callable, Literal
+from typing import Literal
 
-from Pyro5.errors import CommunicationError
 from ansys.tools.common.path import get_available_ansys_installations
 
+from ansys.rocky.core import retry
 from ansys.rocky.core.client import (
     PYROCKY_DEFAULT_PORT,
     RockyClient,
@@ -68,16 +67,12 @@ def _launch_product(
             # Will try to connect to an existing session using the
             # given server port and attempt to close it.
             client = connect(port=server_port)
-            try:
-                client.close()
-            except CommunicationError:
-                # Maybe the session closed in the meantime so we just pass
-                pass
+            client.close()
         else:
             raise LaunchError(f"Port {server_port} is already in use.")
 
     if version is not None and version < MINIMUM_ANSYS_VERSION_SUPPORTED:
-        raise NotSupportedError(
+        raise NotSupportedError(  # pragma: no cover
             f"{product_name} version {version} is not supported. "
             f"The minimum supported version is {MINIMUM_ANSYS_VERSION_SUPPORTED}"
         )
@@ -100,7 +95,7 @@ def _launch_product(
     if rocky_process.returncode is not None:  # pragma: no cover
         raise LaunchError(f"Error launching {product_name}:\n  {' '.join(cmd)}")
 
-    client = _wait_for(
+    client = retry.wait_succeed(
         lambda: connect(port=server_port),
         timeout=connect_timeout,
         expected_exc=ConnectionRefusedError,
@@ -300,8 +295,6 @@ def _is_port_busy(port: int) -> bool:
     ----------
     port : int
         Port to check.
-    timeout : int
-        How long to wait for the port to be freed.
 
     Returns
     -------
@@ -310,7 +303,12 @@ def _is_port_busy(port: int) -> bool:
     """
     import socket
 
-    if sys.platform != "win32":
+    if sys.platform == "win32":
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            # If the socket is able to connect, it means the port is busy.
+            return s.connect_ex(("localhost", port)) == 0
+
+    else:
         socket_path = _uds_socket_path(port)
         if not socket_path.exists():
             return False
@@ -319,20 +317,7 @@ def _is_port_busy(port: int) -> bool:
                 s.settimeout(2)
                 s.connect(str(socket_path))
                 return True
-        except (ConnectionRefusedError, OSError):
-            return False
-    else:
-
-        def try_connect():
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                if s.connect_ex(("localhost", port)) == 0:
-                    raise ConnectionRefusedError(f"Port {port} is busy.")
-
-        try:
-            _wait_for(try_connect, timeout=10, expected_exc=ConnectionRefusedError)
-        except ConnectionRefusedError:
-            return True
-        else:
+        except (ConnectionRefusedError, OSError):  # pragma: no cover
             return False
 
 
@@ -368,7 +353,7 @@ def _find_executable(
         """
         if sys.platform == "win32":
             return Path(installation_path) / f"{product_name}/bin/{product_name}.exe"
-        else:  # pragma: no cover
+        else:
             return Path(installation_path) / f"{product_name.lower()}/{product_name}"
 
     if version is None:
@@ -385,37 +370,3 @@ def _find_executable(
             executable = get_platform_executable_path(ansys_installation, product_name)
 
     return executable
-
-
-def _wait_for(predicate_callback: Callable, *, timeout: int, expected_exc) -> Any:
-    """
-    Repeatedly calls ``predicate_callback`` until it succeeds or timeout is reached.
-
-    Parameters
-    ----------
-    predicate_callback :
-        Callable invoked until it returns successfully.
-    timeout :
-        Maximum wait time in seconds.
-    expected_exc :
-        Exception type to catch and retry while waiting.
-
-    Returns
-    -------
-    Any
-        The return value from ``predicate_callback``.
-
-    Raises
-    ------
-    expected_exc
-        Raised when retries exceed ``timeout``.
-    """
-    started = time.time()
-    while True:
-        try:
-            return predicate_callback()
-        except expected_exc as exc:
-            if (time.time() - started) < timeout:
-                time.sleep(1)
-            else:
-                raise exc

--- a/src/ansys/rocky/core/launcher.py
+++ b/src/ansys/rocky/core/launcher.py
@@ -292,7 +292,7 @@ def launch_container(  # pragma: no cover
     return client
 
 
-def _is_port_busy(port: int, timeout: int = 10) -> bool:
+def _is_port_busy(port: int) -> bool:
     """
     Check if there is already a Rocky server running.
 
@@ -310,13 +310,30 @@ def _is_port_busy(port: int, timeout: int = 10) -> bool:
     """
     import socket
 
-    for _ in range(timeout):
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            if s.connect_ex(("localhost", port)) == 0:
-                time.sleep(1)
-            else:
-                return False
-    return True
+    if sys.platform != "win32":
+        socket_path = _uds_socket_path(port)
+        if not socket_path.exists():
+            return False
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+                s.settimeout(2)
+                s.connect(str(socket_path))
+                return True
+        except (ConnectionRefusedError, OSError):
+            return False
+    else:
+
+        def try_connect():
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                if s.connect_ex(("localhost", port)) == 0:
+                    raise ConnectionRefusedError(f"Port {port} is busy.")
+
+        try:
+            _wait_for(try_connect, timeout=10, expected_exc=ConnectionRefusedError)
+        except ConnectionRefusedError:
+            return True
+        else:
+            return False
 
 
 def _find_executable(
@@ -352,7 +369,7 @@ def _find_executable(
         if sys.platform == "win32":
             return Path(installation_path) / f"{product_name}/bin/{product_name}.exe"
         else:  # pragma: no cover
-            return Path(installation_path) / f"{product_name.lower()}/bin/{product_name}"
+            return Path(installation_path) / f"{product_name.lower()}/{product_name}"
 
     if version is None:
         for installation in sorted(ansys_installations, reverse=True):

--- a/src/ansys/rocky/core/retry.py
+++ b/src/ansys/rocky/core/retry.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import time
+from typing import Any, Callable
+
+
+def wait_succeed(predicate_callback: Callable, *, timeout: int, expected_exc) -> Any:
+    """
+    Repeatedly calls ``predicate_callback`` until it succeeds or timeout is reached.
+
+    Parameters
+    ----------
+    predicate_callback :
+        Callable invoked until it returns successfully.
+    timeout :
+        Maximum wait time in seconds.
+    expected_exc :
+        Exception type to catch and retry while waiting.
+
+    Returns
+    -------
+    Any
+        The return value from ``predicate_callback``.
+
+    Raises
+    ------
+    expected_exc
+        Raised when retries exceed ``timeout``.
+    """
+    started = time.time()
+    while True:
+        try:
+            return predicate_callback()
+        except expected_exc as exc:
+            if (time.time() - started) < timeout:
+                time.sleep(1)
+            else:
+                raise exc

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -19,12 +19,12 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-import time
+import sys
 
 import pytest
 
 import ansys.rocky.core as pyrocky
-from ansys.rocky.core.client import PYROCKY_DEFAULT_PORT
+from ansys.rocky.core.client import PYROCKY_DEFAULT_PORT, _uds_socket_path
 from ansys.rocky.core.exceptions import NotSupportedError
 from ansys.rocky.core.launcher import LaunchError, _wait_for
 
@@ -39,20 +39,39 @@ def test_invalid_rocky_exe_parameter():
         pyrocky.launch_rocky(rocky_exe="C:\\Folder\\Rocky.exe")
 
 
-def test_pyrocky_launch_multiple_servers(version):
+def test_port_busy_check(version):
     """
-    Test that start multiple rocky servers is not allowed.
+    Ensure that launcher checks for busy ports.
     """
     import socket
 
-    # Emulating Rocky server already running by binding socket to the server address.
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        time.sleep(1)  # Wait to ensure the address is properly released before binding
-        s.bind(("localhost", PYROCKY_DEFAULT_PORT))
-        s.listen(10)
+    connect_timeout = 60
 
-        with pytest.raises(LaunchError, match=r"Port \d+ is already in use"):
-            pyrocky.launch_rocky(rocky_version=version)
+    if sys.platform == "win32":
+        # Emulating Rocky server by binding a TCP socket to the server address.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("localhost", PYROCKY_DEFAULT_PORT))
+            s.listen(connect_timeout)
+
+            with pytest.raises(LaunchError, match=r"Port \d+ is already in use"):
+                pyrocky.launch_rocky(
+                    rocky_version=version, connect_timeout=connect_timeout
+                )
+    else:
+        # Emulating Rocky server by binding a UDS socket to the expected path.
+        socket_path = _uds_socket_path(PYROCKY_DEFAULT_PORT)
+        socket_path.parent.mkdir(parents=True, exist_ok=True)
+        assert not socket_path.is_file(), "Unexpected socket file"
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+            s.bind(str(socket_path))
+            s.listen(connect_timeout)
+            try:
+                with pytest.raises(LaunchError, match=r"Port \d+ is already in use"):
+                    pyrocky.launch_rocky(
+                        rocky_version=version, connect_timeout=connect_timeout
+                    )
+            finally:
+                socket_path.unlink(missing_ok=True)
 
 
 def test_launcher_closing_existing_session(version):
@@ -71,6 +90,7 @@ def test_launcher_closing_existing_session(version):
     rocky_two.close()
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="No FreeFlow on Linux CI for now")
 def test_freeflow_launcher(freeflow_session):
     """Test to check if freeflow launcher is working as expected"""
     project = freeflow_session.api.CreateProject()
@@ -93,10 +113,25 @@ def test_connection_timeout(request):
     - Raises ConnectionRefusedError after the configured connect_timeout
     - Can connect after that.
     """
-    with pytest.raises(ConnectionRefusedError, match="Could not connect"):
-        pyrocky.launch_rocky(connect_timeout=1)
+    if sys.platform == "win32":
+        with pytest.raises(ConnectionRefusedError, match="Could not connect"):
+            pyrocky.launch_rocky(connect_timeout=1)
 
-    cli = _wait_for(pyrocky.connect, timeout=30, expected_exc=ConnectionRefusedError)
+        cli = _wait_for(pyrocky.connect, timeout=30, expected_exc=ConnectionRefusedError)
+    else:
+        # On Linux, Rocky uses UDS which connects much faster than TCP.
+        # After the 3-second subprocess startup check, the server is already
+        # available, making it impossible to trigger a connection timeout with
+        # launch_rocky. Test the timeout mechanism directly instead.
+        unused_port = 59999
+        with pytest.raises(ConnectionRefusedError, match="No socket open"):
+            _wait_for(
+                lambda: pyrocky.connect(port=unused_port),
+                timeout=1,
+                expected_exc=ConnectionRefusedError,
+            )
+        cli = pyrocky.launch_rocky()
+
     request.addfinalizer(cli.close)
 
     assert cli.api._pyroConnection

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -26,7 +26,8 @@ import pytest
 import ansys.rocky.core as pyrocky
 from ansys.rocky.core.client import PYROCKY_DEFAULT_PORT, _uds_socket_path
 from ansys.rocky.core.exceptions import NotSupportedError
-from ansys.rocky.core.launcher import LaunchError, _wait_for
+from ansys.rocky.core.launcher import LaunchError
+from ansys.rocky.core.retry import wait_succeed
 
 
 def test_not_supported_version_error():
@@ -45,7 +46,7 @@ def test_port_busy_check(version):
     """
     import socket
 
-    connect_timeout = 60
+    connect_timeout = 30
 
     if sys.platform == "win32":
         # Emulating Rocky server by binding a TCP socket to the server address.
@@ -58,8 +59,9 @@ def test_port_busy_check(version):
                     rocky_version=version, connect_timeout=connect_timeout
                 )
     else:
+        socket_number = 9015
         # Emulating Rocky server by binding a UDS socket to the expected path.
-        socket_path = _uds_socket_path(PYROCKY_DEFAULT_PORT)
+        socket_path = _uds_socket_path(socket_number)
         socket_path.parent.mkdir(parents=True, exist_ok=True)
         assert not socket_path.is_file(), "Unexpected socket file"
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
@@ -68,7 +70,9 @@ def test_port_busy_check(version):
             try:
                 with pytest.raises(LaunchError, match=r"Port \d+ is already in use"):
                     pyrocky.launch_rocky(
-                        rocky_version=version, connect_timeout=connect_timeout
+                        rocky_version=version,
+                        connect_timeout=connect_timeout,
+                        server_port=socket_number,
                     )
             finally:
                 socket_path.unlink(missing_ok=True)
@@ -117,7 +121,9 @@ def test_connection_timeout(request):
         with pytest.raises(ConnectionRefusedError, match="Could not connect"):
             pyrocky.launch_rocky(connect_timeout=1)
 
-        cli = _wait_for(pyrocky.connect, timeout=30, expected_exc=ConnectionRefusedError)
+        cli = wait_succeed(
+            pyrocky.connect, timeout=30, expected_exc=ConnectionRefusedError
+        )
     else:
         # On Linux, Rocky uses UDS which connects much faster than TCP.
         # After the 3-second subprocess startup check, the server is already
@@ -125,7 +131,7 @@ def test_connection_timeout(request):
         # launch_rocky. Test the timeout mechanism directly instead.
         unused_port = 59999
         with pytest.raises(ConnectionRefusedError, match="No socket open"):
-            _wait_for(
+            wait_succeed(
                 lambda: pyrocky.connect(port=unused_port),
                 timeout=1,
                 expected_exc=ConnectionRefusedError,


### PR DESCRIPTION
- Reactivate tests on Linux
- _is_port_busy now checks if a UDS socket is active on non-Windows
  platforms instead of unconditionally returning False.
- test_pyrocky_launch_multiple_servers creates a UDS socket on Linux
  to emulate an existing Rocky server.
- test_connection_timeout tests the timeout mechanism directly on
  Linux since the fast UDS startup prevents triggering a timeout
  through launch_rocky.