### PR TITLE
test: Skip multithreaded API calls test for versions below 261

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,12 @@ repos:
   rev: v2.4.3
   hooks:
   - id: codespell
-    args: ["--skip=pyproject.toml, src/ansys/rocky/app/*"]
+    args:
+    - "--skip"
+    - "pyproject.toml, src/ansys/rocky/app/*"
+    - "--ignore-words"
+    - "doc/styles/config/vocabularies/ANSYS/accept.txt"
+    - "-w"
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,12 +19,9 @@ repos:
   rev: v2.4.3
   hooks:
   - id: codespell
-    args:
-    - "--skip"
-    - "pyproject.toml, src/ansys/rocky/app/*"
-    - "--ignore-words"
-    - "doc/styles/config/vocabularies/ANSYS/accept.txt"
-    - "-w"
+    # Exclude project config file and Rocky generated stubs folder.
+    exclude: ^(pyproject\.toml|src/ansys/rocky/app/.*)$
+    args: ["--ignore-words", "doc/styles/config/vocabularies/ANSYS/accept.txt", "-w"]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -6,3 +6,5 @@ dialogs
 (?i)API
 (?i)pyrocky
 [Pp]ostprocess
+Synopsys
+synopsys

--- a/tests/test_pyrocky_client.py
+++ b/tests/test_pyrocky_client.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 #
 #
@@ -21,7 +21,10 @@
 # SOFTWARE.
 
 from concurrent.futures import ThreadPoolExecutor
+import os
 import sys
+
+import pytest
 
 from ansys.rocky.core.client import RockyClient
 from ansys.rocky.core.rocky_api_proxies import ApiExportToolkitProxy
@@ -105,6 +108,12 @@ def test_pyro_excepthook_installed(rocky_api, capsys) -> None:
     assert "Remote traceback" in out_err.err
 
 
+ANSYS_VERSION = int(os.getenv("ANSYS_VERSION", "261"))
+
+
+@pytest.mark.skipif(
+    ANSYS_VERSION < 261, reason="Support for multithreaded API calls was added in v261."
+)
 def test_multithread_api_calls(rocky_session: RockyClient) -> None:
     """Test that api calls can be executed on distinct threads."""
 


### PR DESCRIPTION
Multithreaded api calls support was added in v261.

- Skip multithreaded API calls test for versions below 261
- Added Synopsys to codespell ignore words list